### PR TITLE
Add test option to preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ CSV=test.csv
 TEMPLATE=test.txt
 ```
 
-Set `TEST=1` to view a preview of the emails without actually sending them.
+Set `PREVIEW=1` to view a preview of the emails without actually sending them.
 
 ```
-TEST=1 CSV=foo.csv TEMPLATE=bar.txt ./mailmerge
+PREVIEW=1 CSV=foo.csv TEMPLATE=bar.txt ./mailmerge
 ```
 
 ### Email Template

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ CSV=test.csv
 TEMPLATE=test.txt
 ```
 
+Set `TEST=1` to view a preview of the emails without actually sending them.
+
+```
+TEST=1 CSV=foo.csv TEMPLATE=bar.txt ./mailmerge
+```
+
 ### Email Template
 
 The first line of the template file is used for the subject line.

--- a/mailmerge
+++ b/mailmerge
@@ -12,11 +12,11 @@ csv_file = ENV['CSV'] || 'test.csv'
 template_file = ENV['TEMPLATE'] || 'test.txt'
 template = File.read(template_file)
 
-Pony.override_options = { :via => :test } if ENV['TEST']
+Pony.override_options = { :via => :test } if ENV['PREVIEW']
 
 CSV.foreach(csv_file, :headers => :first_row) do |row|
   msg = Msg.new(row, template)
   Email.new(msg).dispatch
 end
 
-puts Mail::TestMailer.deliveries if ENV['TEST']
+puts Mail::TestMailer.deliveries if ENV['PREVIEW']

--- a/mailmerge
+++ b/mailmerge
@@ -12,7 +12,11 @@ csv_file = ENV['CSV'] || 'test.csv'
 template_file = ENV['TEMPLATE'] || 'test.txt'
 template = File.read(template_file)
 
+Pony.override_options = { :via => :test } if ENV['TEST']
+
 CSV.foreach(csv_file, :headers => :first_row) do |row|
   msg = Msg.new(row, template)
   Email.new(msg).dispatch
 end
+
+puts Mail::TestMailer.deliveries if ENV['TEST']


### PR DESCRIPTION
Set `TEST=1` to print what would be sent without actually sending it.

```
$ TEST=1 CSV=survey/communities.csv TEMPLATE=survey/template.txt ./mailmerge
Date: Tue, 11 Apr 2017 23:59:08 -0700
From: GitHub Open Source Team <opensource@github.com>
To: lee-dohm@github.com
Message-ID: <58edd03c4e964_dae73ffcfac32530974c@Brandons-MacBook-Pro.local.mail>
Subject: Share the Open Source Survey
Mime-Version: 1.0
Content-Type: text/plain;
 charset=UTF-8
Content-Transfer-Encoding: 7bit


Hi Lee,

Thanks for your interest in having the Atom community participate in the Open Source Survey. We are ready to start running the survey for your community. Please share the link in the email template below. The survey will conclude on April 28.
…
```
