### PR TITLE
change .net to .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ https://security.google.com/settings/security/apppasswords
 SMTP_LOGIN=<your gmail address>
 SMTP_PASSWORD=<your app-specific password>
 SMTP_PORT=587
-SMTP_SERVER=smtp.gmail.net
+SMTP_SERVER=smtp.gmail.com
 ```
 
 ## Sending Emails


### PR DESCRIPTION
The SMTP for sending from your Gmail address is ``smtp.gmail.com``. Ran into error with current suggestion, and this fixed it.